### PR TITLE
Add initial tests and testing instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ build/
 # RL-Reason-Game specific outputs
 rl-reason-game/models/
 rl-reason-game/wandb/
+
+# Python caches
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -329,3 +329,17 @@ You can integrate additional LLM models by updating the `MODEL_LIST` in `cluedo_
 ## Contributing
 
 Contributions welcome! Please feel free to submit a Pull Request.
+## Running Tests
+
+### Node.js Tests
+Run the built-in Node test runner for JavaScript components:
+```bash
+cd cluedo_game_engine
+npm test
+```
+
+### Python Tests
+Run pytest for the Python utilities and scripts:
+```bash
+pytest
+```

--- a/cluedo_game_engine/package.json
+++ b/cluedo_game_engine/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon --ignore '*.log' --ignore 'logs/*' --ignore 'game_results.json' src/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test ../tests/*.test.js",
     "run-games": "node src/index.js --run-games",
     "run-games:3": "node src/index.js --run-games --num-games=3",
     "run-games:openrouter": "node src/index.js --run-games --num-games=3 --llm-backend=openrouter"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@
 flask
 openai
 uvicorn
-# Add other dependencies if needed 
+pytest
+# Add other dependencies if needed

--- a/tests/Agent.test.js
+++ b/tests/Agent.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Agent } from '../cluedo_game_engine/src/models/Agent.js';
+
+test('constructor stores initial cards in memory', () => {
+  const agent = new Agent('Alice', ['Knife', 'Rope'], 'gpt', 'game1');
+  assert.ok(agent.cards instanceof Set);
+  assert.ok(agent.memory.knownCards.has('Knife'));
+  assert.ok(agent.memory.knownCards.has('Rope'));
+});
+
+test('setLost marks agent as lost and updates memory', () => {
+  const agent = new Agent('Bob', [], 'gpt', 'game1');
+  agent.setLost();
+  assert.ok(agent.hasLost);
+  assert.ok(agent.memory.currentMemory.includes('incorrect accusation'));
+});

--- a/tests/Memory.test.js
+++ b/tests/Memory.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Memory } from '../cluedo_game_engine/src/models/Memory.js';
+
+test('addKnownCard updates sets correctly', () => {
+  const memory = new Memory('agent1');
+  memory.suspectedCards.set('Candlestick', 0.5);
+  memory.eliminatedCards.add('Candlestick');
+  memory.addKnownCard('Candlestick');
+  assert.ok(memory.knownCards.has('Candlestick'));
+  assert.ok(!memory.suspectedCards.has('Candlestick'));
+  assert.ok(!memory.eliminatedCards.has('Candlestick'));
+});
+
+test('doesPlayerNotHaveCard reflects negative constraints', () => {
+  const memory = new Memory('agent2');
+  memory.playerNegativeConstraints.set('Alice', new Set(['Rope']));
+  assert.ok(memory.doesPlayerNotHaveCard('Alice', 'Rope'));
+  assert.ok(!memory.doesPlayerNotHaveCard('Alice', 'Knife'));
+});
+
+test('reset clears memory state', () => {
+  const memory = new Memory('agent3');
+  memory.addKnownCard('Lead Pipe');
+  memory.suspectedCards.set('Wrench', 0.7);
+  memory.eliminatedCards.add('Revolver');
+  memory.playerNegativeConstraints.set('Bob', new Set(['Library']));
+  memory.currentMemory = 'some memory';
+  memory.memoryHistory.push({ turnNumber: 1 });
+  memory.reset();
+  assert.equal(memory.knownCards.size, 1);
+  assert.ok(memory.knownCards.has('Lead Pipe'));
+  assert.equal(memory.suspectedCards.size, 0);
+  assert.equal(memory.eliminatedCards.size, 0);
+  assert.equal(memory.playerNegativeConstraints.size, 0);
+  assert.equal(memory.currentMemory, '');
+  assert.equal(memory.memoryHistory.length, 0);
+});

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,29 @@
+import sys
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+os.chdir(ROOT / 'cluedo_game_engine')
+sys.path.append(str(ROOT / 'scripts' / 'utility'))
+
+from leaderboard import analyze_games
+
+
+def test_analyze_games_basic():
+    data = [{
+        'winner': {'model': 'ModelA'},
+        'totalTurns': 8,
+        'players': [
+            {'model': 'ModelA', 'name': 'A', 'missedOpportunities': [{'turn': 2}]},
+            {'model': 'ModelB', 'name': 'B', 'missedOpportunities': []}
+        ]
+    }]
+
+    stats = analyze_games(data)
+    assert stats['ModelA']['games_played'] == 1
+    assert stats['ModelA']['games_won'] == 1
+    assert stats['ModelA']['avg_completion_time'] == 8
+    assert stats['ModelA']['risk_aversion_score'] == 6
+    assert stats['ModelB']['games_played'] == 1
+    assert stats['ModelB']['games_won'] == 0
+


### PR DESCRIPTION
## Summary
- add basic unit tests for Agent and Memory models
- provide Python unit test for game leaderboard analysis
- document test execution for Node and Python

## Testing
- `cd cluedo_game_engine && npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b5eb28ec83219f5524547f4057d9