### PR TITLE
Guard debug print and replace exit with sys.exit

### DIFF
--- a/scripts/evaluation/evaluate_cluedo_model.py
+++ b/scripts/evaluation/evaluate_cluedo_model.py
@@ -1,8 +1,8 @@
-print("=== DEBUG: Running evaluate_cluedo_model.py version with detailed JSONDecodeError reporting (v_debug_json_err_reporting) ===")
 import os
 import json
 import argparse
 import random
+import sys
 from predibase import Predibase
 import ast # For literal_eval
 import yaml # For parsing model output
@@ -19,7 +19,7 @@ try:
     print("Predibase client initialized successfully.")
 except Exception as e:
     print(f"Error initializing Predibase client: {e}")
-    exit(1)
+    sys.exit(1)
 
 # --- Reward Function Logic (adapted from predibase_clue_train.py for evaluation) ---
 def extract_yaml_from_completion(completion: str):
@@ -525,6 +525,7 @@ def main(args):
         print("No results to summarize.")
 
 if __name__ == "__main__":
+    print("=== DEBUG: Running evaluate_cluedo_model.py version with detailed JSONDecodeError reporting (v_debug_json_err_reporting) ===")
     parser = argparse.ArgumentParser(description="Evaluate a fine-tuned Cluedo model on a test set.")
     parser.add_argument("--llm_interactions_path", help="Path to the full llm_interactions.json file. Required if --input_eval_csv is not used.")
     

--- a/scripts/evaluation/prompt_predibase_model.py
+++ b/scripts/evaluation/prompt_predibase_model.py
@@ -1,5 +1,6 @@
 import os
 import argparse
+import sys
 from predibase import Predibase
 
 # --- Configuration ---
@@ -14,7 +15,8 @@ try:
 except Exception as e:
     print(f"Error initializing Predibase client: {e}")
     print("Ensure PREDIBASE_API_KEY environment variable is set correctly.")
-    exit(1)
+    sys.exit(1)
+
 
 def prompt_model(deployment_name: str, adapter_id_str: str, prompt_text: str, max_new_tokens: int = 256):
     """
@@ -41,7 +43,7 @@ def prompt_model(deployment_name: str, adapter_id_str: str, prompt_text: str, ma
             adapter_id=adapter_id_str,
             max_new_tokens=max_new_tokens
         )
-        
+
         print("\n--- Model Response ---")
         print(response.generated_text)
         print("----------------------")
@@ -54,16 +56,17 @@ def prompt_model(deployment_name: str, adapter_id_str: str, prompt_text: str, ma
         print(f"2. The adapter '{adapter_id_str}' exists and is compatible.")
         print("3. Your API key has the necessary permissions.")
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Prompt a Predibase model with a specific adapter.")
-    parser.add_argument("--deployment", default="qwen2-5-7b-instruct", 
+    parser.add_argument("--deployment", default="qwen2-5-7b-instruct",
                         help="Name of the base model deployment in Predibase (default: qwen2-5-7b-instruct).")
-    parser.add_argument("--adapter", required=True, 
+    parser.add_argument("--adapter", required=True,
                         help="Full adapter ID (e.g., 'your_repo/adapter_name/version' or 'adapter_name/version').")
     parser.add_argument("--prompt", required=True, help="The prompt text to send to the model.")
-    parser.add_argument("--max-tokens", type=int, default=256, 
+    parser.add_argument("--max-tokens", type=int, default=256,
                         help="Maximum new tokens to generate (default: 256).")
-    
+
     args = parser.parse_args()
 
     # Construct the full adapter ID if it doesn't contain a slash (assuming it's in the default repo)
@@ -73,4 +76,5 @@ if __name__ == "__main__":
     # Example: if user provides 'my_adapter/1' and your repo is 'my_org', it should be 'my_org/my_adapter/1'
     # The pb.deployments.client(deployment_name).generate(..., adapter_id=...) expects the full path.
 
-    prompt_model(args.deployment, adapter_id, args.prompt, max_new_tokens=args.max_tokens) 
+    prompt_model(args.deployment, adapter_id, args.prompt, max_new_tokens=args.max_tokens)
+

--- a/scripts/training/predibase_clue_train.py
+++ b/scripts/training/predibase_clue_train.py
@@ -1,5 +1,6 @@
 import os
 import ast
+import sys
 import yaml  # Requires PyYAML (pip install PyYAML)
 from pathlib import Path
 from predibase import Predibase, GRPOConfig, RewardFunctionsConfig
@@ -117,7 +118,7 @@ try:
 except Exception as e:
     print(f"Error initializing Predibase client: {e}")
     print("Ensure PREDIBASE_API_KEY environment variable is set correctly.")
-    exit(1)
+    sys.exit(1)
 
 # --- Get the dataset from Predibase by Name ---
 print(f"Attempting to retrieve dataset '{PREDIBASE_DATASET_NAME}' from Predibase...")
@@ -128,7 +129,7 @@ try:
 except Exception as e:
     print(f"Error retrieving dataset '{PREDIBASE_DATASET_NAME}': {e}")
     print("Please ensure the dataset name is correct and it exists in your Predibase account.")
-    exit(1)
+    sys.exit(1)
 
 # --- Configure Reward Functions ---
 # We only need the memory update reward since we assume the dataset is filtered


### PR DESCRIPTION
## Summary
- ensure Predibase scripts use `sys.exit(1)` instead of `exit(1)`
- move evaluation debug print under `__main__` guard

## Testing
- `python -m py_compile scripts/training/predibase_clue_train.py scripts/evaluation/prompt_predibase_model.py scripts/evaluation/evaluate_cluedo_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6896b5e9ef588321a75d03c80fb31996