### PR TITLE
Use glob to locate evaluation summary file

### DIFF
--- a/scripts/plot_model_summary.py
+++ b/scripts/plot_model_summary.py
@@ -1,28 +1,73 @@
+import glob
+import argparse
+from typing import Optional
+
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-# Load the summary scores CSV
-df = pd.read_csv("*/results/evaluation_reports/all_providers_default_eval/comprehensive_evaluation_report_20250511_162229_summary_scores.csv")
 
-# Set up the plot style
-sns.set(style="whitegrid")
-metrics = ["Average_Precision", "Average_Recall", "Average_F1_Score", "Average_ExactMatch"]
+def main(summary_scores_path: Optional[str] = None) -> None:
+    """Plot model performance summary scores.
 
-# Melt the DataFrame for easier plotting
-df_melted = df.melt(id_vars="Model", value_vars=metrics, var_name="Metric", value_name="Score")
+    Parameters
+    ----------
+    summary_scores_path: optional str
+        Path to a CSV file containing summary scores. If not provided the
+        function searches ``results/evaluation_reports`` for a matching file.
+    """
+    if summary_scores_path is None:
+        matches = glob.glob(
+            "results/evaluation_reports/**/*_summary_scores.csv", recursive=True
+        )
+        if not matches:
+            raise FileNotFoundError(
+                "No summary scores CSV found in results/evaluation_reports"
+            )
+        summary_scores_path = matches[0]
 
-plt.figure(figsize=(14, 7))
-sns.barplot(
-    data=df_melted,
-    x="Score",
-    y="Model",
-    hue="Metric",
-    palette="viridis"
-)
-plt.title("Model Performance Comparison")
-plt.xlabel("Score")
-plt.ylabel("Model")
-plt.legend(title="Metric")
-plt.tight_layout()
-plt.show()
+    # Load the summary scores CSV
+    df = pd.read_csv(summary_scores_path)
+
+    # Set up the plot style
+    sns.set(style="whitegrid")
+    metrics = [
+        "Average_Precision",
+        "Average_Recall",
+        "Average_F1_Score",
+        "Average_ExactMatch",
+    ]
+
+    # Melt the DataFrame for easier plotting
+    df_melted = df.melt(
+        id_vars="Model", value_vars=metrics, var_name="Metric", value_name="Score"
+    )
+
+    plt.figure(figsize=(14, 7))
+    sns.barplot(
+        data=df_melted,
+        x="Score",
+        y="Model",
+        hue="Metric",
+        palette="viridis",
+    )
+    plt.title("Model Performance Comparison")
+    plt.xlabel("Score")
+    plt.ylabel("Model")
+    plt.legend(title="Metric")
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Plot summary scores for model evaluation"
+    )
+    parser.add_argument(
+        "--summary-scores-path",
+        default=None,
+        help="Path to the summary_scores.csv file. If not provided, searches in results/evaluation_reports.",
+    )
+    args = parser.parse_args()
+    main(args.summary_scores_path)
+


### PR DESCRIPTION
## Summary
- Replace hard-coded summary score path with glob search
- Add optional `--summary-scores-path` argument and CLI entry point for plotting

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896b5e922f0832181b87b035ec15f4c