### PR TITLE
feat: make agent memory retrieval async

### DIFF
--- a/cluedo_game_engine/src/models/Agent.js
+++ b/cluedo_game_engine/src/models/Agent.js
@@ -257,12 +257,13 @@ export class Agent {
 
   /**
    * Gets a formatted representation of this agent's memory state.
-   * 
-   * @returns {Object} The agent's current memory and model
+   *
+   * @returns {Promise<Object>} The agent's current memory and model
    */
-  getMemoryState() {
+  async getMemoryState() {
+    const memoryState = await this.memory.formatMemoryForLLM();
     return {
-      ...this.memory.formatMemoryForLLM(),
+      ...memoryState,
       model: this.model
     };
   }


### PR DESCRIPTION
## Summary
- make Agent#getMemoryState asynchronous
- combine formatted memory with model

## Testing
- `npm test` (fails: Error: no test specified)
- `npx eslint src/models/Agent.js` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_e_6896b5e734988321a52b5bf9cf173eaa