### PR TITLE
Initialize agent memory with name and link game

### DIFF
--- a/cluedo_game_engine/src/models/Agent.js
+++ b/cluedo_game_engine/src/models/Agent.js
@@ -18,17 +18,18 @@ export class Agent {
    * @param {string} name - The agent's name/identifier
    * @param {Array<string>} cards - Cards in the agent's hand
    * @param {string} model - The LLM model to use for this agent
-   * @param {string|Object} gameId - Game identifier or reference
+   * @param {Object} gameRef - Reference to the game instance
    */
-  constructor(name, cards, model, gameId) {
+  constructor(name, cards, model, gameRef) {
     this.name = name;
     this.cards = new Set(cards); // Ensure cards is a Set
     this.model = model;
     this.hasLost = false;
-    this.game = null; // Will be set by the Game class
-    
+    this.game = gameRef;
+
     // Initialize memory system
-    this.memory = new Memory(gameId);
+    this.memory = new Memory(name);
+    this.memory.game = gameRef;
     
     // Initialize with known cards
     cards.forEach(card => this.memory.addKnownCard(card));

--- a/cluedo_game_engine/src/models/Memory.js
+++ b/cluedo_game_engine/src/models/Memory.js
@@ -1,4 +1,7 @@
 export class Memory {
+  /**
+   * @param {string} agentId - Unique identifier for the agent (usually the agent's name)
+   */
   constructor(agentId) {
     this.agentId = agentId;
     
@@ -196,6 +199,7 @@ export class Memory {
          suggestionCards = [event.suspect, event.weapon, event.room];
       }
       // Direct card shown TO this agent (or by this agent)
+      // event.from and event.to contain agent names
       else if (event.type === 'cardShown' && event.card) {
          if (event.from === this.agentId) {
              // We showed the card


### PR DESCRIPTION
## Summary
- Pass agent name to Memory and attach game reference so events can be resolved by name
- Clarify Memory constructor argument as agentId and document
- Note card update logic uses agent names for comparisons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896b5e621688321b82163115a89c9cc