### PR TITLE
Expose agent memory updates to client UI

### DIFF
--- a/cluedo_game_engine/public/app.js
+++ b/cluedo_game_engine/public/app.js
@@ -62,6 +62,20 @@ socket.on('game-event', (event) => {
   }
 });
 
+socket.on('memory-update', (data) => {
+  const panel = document.getElementById('memory-panel');
+  if (!panel) return;
+  let section = panel.querySelector(`[data-agent="${data.agent}"]`);
+  if (!section) {
+    section = document.createElement('div');
+    section.className = 'agent-memory';
+    section.setAttribute('data-agent', data.agent);
+    section.innerHTML = `<h3>${data.agent}</h3><pre class="memory-summary"></pre>`;
+    panel.appendChild(section);
+  }
+  section.querySelector('.memory-summary').textContent = JSON.stringify(data.summary, null, 2);
+});
+
 let isHumanPlayer = false;
 let playerIndex = -1;
 

--- a/cluedo_game_engine/public/index.html
+++ b/cluedo_game_engine/public/index.html
@@ -49,6 +49,11 @@
           <h2>Investigation Log</h2>
           <div id="log-messages"></div>
         </div>
+
+        <div class="memory-panel">
+          <h2>Agent Memory</h2>
+          <div id="memory-panel"></div>
+        </div>
       </div>
 
       <div class="players-panel">
@@ -172,6 +177,20 @@
       solutionDisplay.textContent = `${solution.suspect} in the ${solution.room} with the ${solution.weapon}`;
     });
 
+    socket.on('memory-update', (data) => {
+      const panel = document.getElementById('memory-panel');
+      if (!panel) return;
+      let section = panel.querySelector(`[data-agent="${data.agent}"]`);
+      if (!section) {
+        section = document.createElement('div');
+        section.className = 'agent-memory';
+        section.setAttribute('data-agent', data.agent);
+        section.innerHTML = `<h3>${data.agent}</h3><pre class="memory-summary"></pre>`;
+        panel.appendChild(section);
+      }
+      section.querySelector('.memory-summary').textContent = JSON.stringify(data.summary, null, 2);
+    });
+
     // Function to update game board with highlighted rooms
     function updateGameBoard(turnHistory) {
       // Reset all rooms
@@ -284,6 +303,26 @@
       padding: 20px;
       height: 400px;
       overflow-y: auto;
+    }
+
+    .memory-panel {
+      background: #2a2a2a;
+      border-radius: 8px;
+      padding: 20px;
+      height: 400px;
+      overflow-y: auto;
+    }
+
+    #memory-panel .agent-memory {
+      margin-bottom: 12px;
+    }
+
+    #memory-panel pre {
+      background: #333;
+      padding: 8px;
+      border-radius: 4px;
+      color: #ddd;
+      white-space: pre-wrap;
     }
 
     #log-messages {

--- a/cluedo_game_engine/src/models/Game.js
+++ b/cluedo_game_engine/src/models/Game.js
@@ -677,10 +677,31 @@ export class Game extends EventEmitter {
               // Call LLM to update memory and get its deductions
               const turnEventsForLLM = this.formatTurnEvents(suggestingAgent, suggestion, challengeResult, agent);
               this.logger.debug(`Turn events for ${agent.name}: ${JSON.stringify(turnEventsForLLM)}`);
-              
+
               const llmMemoryUpdateResult = await LLMService.updateMemory(agent, agent.memory, turnEventsForLLM);
               const llmDeductions = llmMemoryUpdateResult.deducedCards || [];
               this.logger.info(`LLM deductions for ${agent.name}: ${llmDeductions.length > 0 ? llmDeductions.join(', ') : 'None'}`);
+
+              // Emit memory summary after each agent's memory update
+              try {
+                  const memorySummary = await agent.memory.formatMemoryForLLM();
+                  this.emit('memory-update', { agent: agent.name, summary: memorySummary });
+                  this.turnHistory.push({
+                      turnNumber: this.currentTurn,
+                      agent: agent.name,
+                      action: 'memory-update',
+                      summary: memorySummary
+                  });
+                  this.gameLog.push({
+                      type: 'MEMORY_UPDATE',
+                      agent: agent.name,
+                      summary: memorySummary,
+                      timestamp: new Date(),
+                      turn: this.currentTurn
+                  });
+              } catch (memError) {
+                  this.logger.error(`Failed to emit memory update for ${agent.name}: ${memError.message}`, { error: memError });
+              }
 
               // Calculate Reward and Log Comparison
               const reward = this.calculateDeductionReward(llmDeductions, groundTruthDeductions);

--- a/cluedo_game_engine/src/server.js
+++ b/cluedo_game_engine/src/server.js
@@ -134,6 +134,11 @@ export async function startServer() {
           });
         });
 
+        // Forward memory updates to clients
+        game.on('memory-update', (data) => {
+          io.emit('memory-update', data);
+        });
+
         // Send initial state
         socket.emit('game-state', game.getGameSummary());
         


### PR DESCRIPTION
## Summary
- Emit `memory-update` events after each agent's memory refresh and log them for turn history.
- Forward `memory-update` events from the game server to connected clients.
- Display per-agent memory summaries in a new memory panel on the front-end.

## Testing
- `npm test`
- `pytest tests/test_leaderboard.py`


------
https://chatgpt.com/codex/tasks/task_e_689b08e25ab883218706efcb8867844d