### PR TITLE
Store and broadcast completed game logs

### DIFF
--- a/cluedo_game_engine/public/index.html
+++ b/cluedo_game_engine/public/index.html
@@ -7,10 +7,11 @@
 <body>
   <div id="mode-selection" class="center-screen">
     <h1>AI Cluedo</h1>
-    <div class="mode-options">
-      <button onclick="startGame('spectate')">Start Game</button>
+      <div class="mode-options">
+        <button onclick="startGame('spectate')">Start Game</button>
+        <a href="/results" class="leaderboard-link" target="_blank">Leaderboard</a>
+      </div>
     </div>
-  </div>
 
   <div id="game-container" class="hidden">
     <div class="container">
@@ -67,11 +68,27 @@
     </div>
   </div>
 
-  <div id="shown-card-history"></div>
+    <div id="shown-card-history"></div>
 
-  <script src="/socket.io/socket.io.js"></script>
-  <script>
-    const socket = io();
+    <div id="past-games">
+      <h2>Past Games</h2>
+      <div id="past-games-list"></div>
+    </div>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script>
+      const socket = io();
+      const pastGames = [];
+
+      socket.on('past-games', (games) => {
+        pastGames.push(...games);
+        renderPastGames();
+      });
+
+      socket.on('game-log', (data) => {
+        pastGames.push(data);
+        renderPastGames();
+      });
     
     function startGame(mode) {
       document.getElementById('mode-selection').classList.add('hidden');
@@ -173,33 +190,48 @@
     });
 
     // Function to update game board with highlighted rooms
-    function updateGameBoard(turnHistory) {
-      // Reset all rooms
-      document.querySelectorAll('.room').forEach(room => {
-        room.classList.remove('suggested', 'recent-suggestion');
-        room.querySelector('.room-indicator').textContent = '';
-      });
+      function updateGameBoard(turnHistory) {
+        // Reset all rooms
+        document.querySelectorAll('.room').forEach(room => {
+          room.classList.remove('suggested', 'recent-suggestion');
+          room.querySelector('.room-indicator').textContent = '';
+        });
 
-      // Get recent suggestions (last 3 turns)
-      const recentSuggestions = turnHistory
-        .filter(turn => turn.action === 'suggestion')
-        .slice(-3);
+        // Get recent suggestions (last 3 turns)
+        const recentSuggestions = turnHistory
+          .filter(turn => turn.action === 'suggestion')
+          .slice(-3);
 
-      // Highlight suggested rooms
-      recentSuggestions.forEach((turn, index) => {
-        const roomElement = document.querySelector(`.room[data-room="${turn.suggestion.room}"]`);
-        if (roomElement) {
-          roomElement.classList.add('suggested');
-          if (index === recentSuggestions.length - 1) {
-            roomElement.classList.add('recent-suggestion');
-            // Add agent indicator
-            const indicator = roomElement.querySelector('.room-indicator');
-            indicator.textContent = turn.agent.charAt(0).toUpperCase();
+        // Highlight suggested rooms
+        recentSuggestions.forEach((turn, index) => {
+          const roomElement = document.querySelector(`.room[data-room="${turn.suggestion.room}"]`);
+          if (roomElement) {
+            roomElement.classList.add('suggested');
+            if (index === recentSuggestions.length - 1) {
+              roomElement.classList.add('recent-suggestion');
+              // Add agent indicator
+              const indicator = roomElement.querySelector('.room-indicator');
+              indicator.textContent = turn.agent.charAt(0).toUpperCase();
+            }
           }
-        }
-      });
-    }
-  </script>
+        });
+      }
+
+      function renderPastGames() {
+        const list = document.getElementById('past-games-list');
+        list.innerHTML = pastGames.map((game, idx) => {
+          const lines = game.log.map(entry => {
+            const time = new Date(entry.timestamp).toLocaleTimeString();
+            let line = `[${time}] ${entry.agent || 'System'} - ${entry.type}`;
+            if (entry.message) line += `: ${entry.message}`;
+            if (entry.reasoning) line += `\nReasoning: ${entry.reasoning}`;
+            if (entry.memory) line += `\nMemory: ${entry.memory}`;
+            return line;
+          }).join('\n');
+          return `<details><summary>Game ${idx + 1} - ${game.winner || 'No winner'} (<a href="/results" target="_blank">Leaderboard</a>)</summary><pre class="game-log">${lines}</pre></details>`;
+        }).join('');
+      }
+    </script>
 
   <style>
     /* Updated layout styles */

--- a/cluedo_game_engine/public/style.css
+++ b/cluedo_game_engine/public/style.css
@@ -192,12 +192,12 @@ body {
   100% { transform: scale(1); opacity: 1; }
 }
 
-.player-marker.red-agent { 
-  background: #ff6b6b; 
+.player-marker.red-agent {
+  background: #ff6b6b;
   content: "R";
 }
-.player-marker.blue-agent { 
-  background: #4ecdc4; 
+.player-marker.blue-agent {
+  background: #4ecdc4;
   content: "B";
 }
 .player-marker.green-agent { 
@@ -483,4 +483,28 @@ body {
   color: #7f8c8d;
   font-size: 0.8em;
   text-align: right;
-} 
+}
+
+#past-games {
+  margin-top: 20px;
+}
+
+#past-games details {
+  background: #2a2a2a;
+  margin-bottom: 10px;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+#past-games pre {
+  background: #333;
+  padding: 10px;
+  border-radius: 4px;
+  white-space: pre-wrap;
+}
+
+.mode-options .leaderboard-link {
+  margin-left: 10px;
+  color: #4ecdc4;
+  text-decoration: none;
+}

--- a/cluedo_game_engine/src/server.js
+++ b/cluedo_game_engine/src/server.js
@@ -7,6 +7,7 @@ import { GameResult } from './models/GameResult.js';
 import { parseArgs } from 'node:util';
 
 let game = null;
+const completedGames = [];
 
 export async function startServer() {
   // Parse command line arguments
@@ -52,6 +53,8 @@ export async function startServer() {
   app.use(express.static('public'));
   
   io.on('connection', (socket) => {
+    socket.emit('past-games', completedGames);
+
     socket.on('game-mode', async (mode) => {
       try {
         // Always create a new game when mode is selected
@@ -332,7 +335,16 @@ async function runGameLoop(game) {
         })) || [],
         timestamp: new Date().toISOString(),
         solution: game.solution,
-        totalTurns: game.currentTurn
+        totalTurns: game.currentTurn,
+        detailedLog: game.gameLog.map(entry => {
+            const time = new Date(entry.timestamp).toISOString();
+            const agent = entry.agent || 'System';
+            const base = `[${time}] ${agent} - ${entry.type}`;
+            const message = entry.message ? `: ${entry.message}` : '';
+            const reasoning = entry.reasoning ? `\nReasoning: ${entry.reasoning}` : '';
+            const memory = entry.memory ? `\nMemory: ${entry.memory}` : '';
+            return base + message + reasoning + memory;
+        })
     };
 
     if (game.winner) {
@@ -344,16 +356,25 @@ async function runGameLoop(game) {
         } catch (saveError) {
             console.error('[runGameLoop] Error occurred during GameResult.saveResults:', saveError);
         }
-    } else {
-        console.log('Game ended without a winner');
-        console.log('[runGameLoop] Attempting to save results (no winner)...');
-        try {
-            await GameResult.saveResults(resultData);
-            console.log('[runGameLoop] Results save call completed (no winner).');
-        } catch (saveError) {
-            console.error('[runGameLoop] Error occurred during GameResult.saveResults (no winner):', saveError);
-        }
-    }
+      } else {
+          console.log('Game ended without a winner');
+          console.log('[runGameLoop] Attempting to save results (no winner)...');
+          try {
+              await GameResult.saveResults(resultData);
+              console.log('[runGameLoop] Results save call completed (no winner).');
+          } catch (saveError) {
+              console.error('[runGameLoop] Error occurred during GameResult.saveResults (no winner):', saveError);
+          }
+      }
+
+      const gameData = {
+        log: game.gameLog,
+        solution: game.solution,
+        winner: game.winner ? game.winner.name : null
+      };
+      completedGames.push(gameData);
+      const gameIndex = completedGames.length;
+      game.io?.emit('game-log', { ...gameData, gameIndex });
     
   } catch (error) {
     console.error('Game loop error:', error);


### PR DESCRIPTION
## Summary
- Persist completed game logs and solutions server-side and broadcast them to connected clients
- Add client-side history viewer for past games and link to leaderboard
- Style past game listings and leaderboard link

## Testing
- `npm test`
- `pytest tests/test_leaderboard.py`


------
https://chatgpt.com/codex/tasks/task_e_689b08e6526883218dbca1acc1b17274