### PR TITLE
Add multi-game mode with live leaderboard

### DIFF
--- a/cluedo_game_engine/public/app.js
+++ b/cluedo_game_engine/public/app.js
@@ -62,6 +62,24 @@ socket.on('game-event', (event) => {
   }
 });
 
+socket.on('leaderboard-update', (stats) => {
+  const tbody = document.querySelector('#leaderboard tbody');
+  if (!tbody) return;
+  const rows = Object.values(stats)
+    .sort((a, b) => b.win_rate - a.win_rate)
+    .map(entry => `
+      <tr>
+        <td>${entry.model_name}</td>
+        <td>${entry.games_played}</td>
+        <td>${entry.games_won}</td>
+        <td>${entry.win_rate}</td>
+        <td>${entry.avg_completion_time}</td>
+      </tr>
+    `)
+    .join('');
+  tbody.innerHTML = rows;
+});
+
 let isHumanPlayer = false;
 let playerIndex = -1;
 

--- a/cluedo_game_engine/public/index.html
+++ b/cluedo_game_engine/public/index.html
@@ -9,6 +9,7 @@
     <h1>AI Cluedo</h1>
     <div class="mode-options">
       <button onclick="startGame('spectate')">Start Game</button>
+      <button onclick="startGame('multi')">Run Multiple Games</button>
     </div>
   </div>
 
@@ -63,6 +64,22 @@
           </div>
           <div id="players-list"></div>
         </div>
+      </div>
+
+      <div class="leaderboard-panel">
+        <h2>Leaderboard</h2>
+        <table id="leaderboard">
+          <thead>
+            <tr>
+              <th>Model</th>
+              <th>Games</th>
+              <th>Wins</th>
+              <th>Win %</th>
+              <th>Avg Turns</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
       </div>
     </div>
   </div>
@@ -428,6 +445,24 @@
       background: rgba(74, 158, 255, 0.1);
       padding: 2px 6px;
       border-radius: 4px;
+    }
+
+    .leaderboard-panel {
+      background: #2a2a2a;
+      padding: 20px;
+      border-radius: 8px;
+      margin-top: 20px;
+    }
+
+    #leaderboard {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    #leaderboard th,
+    #leaderboard td {
+      padding: 4px 8px;
+      text-align: left;
     }
 
     /* Current turn styles */

--- a/cluedo_game_engine/src/server.js
+++ b/cluedo_game_engine/src/server.js
@@ -5,6 +5,34 @@ import { Game } from './models/Game.js';
 import { runGame } from './gameLogic.js';
 import { GameResult } from './models/GameResult.js';
 import { parseArgs } from 'node:util';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// In-memory store of completed games
+const gameResults = [];
+
+function computeLeaderboard(results) {
+  const scriptPath = path.resolve(__dirname, '../../scripts/utility').replace(/\\/g, '/');
+  const pyCode = `import json,sys,os\nsys.path.append('${scriptPath}')\nfrom leaderboard import analyze_games\ndata=json.loads(sys.stdin.read())\nprint(json.dumps(analyze_games(data)))`;
+  const out = spawnSync('python', ['-c', pyCode], {
+    input: JSON.stringify(results),
+    encoding: 'utf-8'
+  });
+  if (out.status !== 0) {
+    console.error('Leaderboard generation failed:', out.stderr);
+    return {};
+  }
+  try {
+    return JSON.parse(out.stdout);
+  } catch (err) {
+    console.error('Failed to parse leaderboard output:', err);
+    return {};
+  }
+}
 
 let game = null;
 
@@ -48,12 +76,42 @@ export async function startServer() {
   const app = express();
   const server = createServer(app);
   const io = new Server(server);
-  
+
   app.use(express.static('public'));
+
+  function handleGameResult(result) {
+    gameResults.push(result);
+    io.emit('game-complete', {
+      winner: result.winner,
+      totalTurns: result.totalTurns,
+      players: result.players
+    });
+    const leaderboard = computeLeaderboard(gameResults);
+    io.emit('leaderboard-update', leaderboard);
+  }
   
   io.on('connection', (socket) => {
     socket.on('game-mode', async (mode) => {
       try {
+        if (mode === 'multi') {
+          const numGames = 5;
+          for (let i = 0; i < numGames; i++) {
+            const multiGame = new Game('spectate', io);
+            await multiGame.initialize();
+            const result = await runGameLoop(multiGame);
+            handleGameResult(result);
+
+            if (multiGame.agents) {
+              for (const agent of multiGame.agents) {
+                await agent.memory.reset();
+              }
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 1000));
+          }
+          return;
+        }
+
         // Always create a new game when mode is selected
         game = new Game(mode, io);
         await game.initialize();
@@ -139,7 +197,8 @@ export async function startServer() {
         
         if (mode === 'spectate') {
           console.log('Starting AI-only game...');
-          runGameLoop(game);
+          const result = await runGameLoop(game);
+          handleGameResult(result);
         }
       } catch (error) {
         console.error('Failed to start game:', error);
@@ -354,7 +413,8 @@ async function runGameLoop(game) {
             console.error('[runGameLoop] Error occurred during GameResult.saveResults (no winner):', saveError);
         }
     }
-    
+
+    return resultData;
   } catch (error) {
     console.error('Game loop error:', error);
     console.error('Game state:', {
@@ -365,4 +425,4 @@ async function runGameLoop(game) {
     });
     console.error(error.stack);
   }
-} 
+}


### PR DESCRIPTION
## Summary
- support multi-game sessions from the client without exiting process
- emit game-complete results and live leaderboard updates after each game
- render leaderboard on the client

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b0915730083218bb435fba9391d80