### PR TITLE
Add single/multi game mode selection to UI

### DIFF
--- a/cluedo_game_engine/public/app.js
+++ b/cluedo_game_engine/public/app.js
@@ -285,9 +285,9 @@ function startGame(mode) {
     
     // Notify server of mode choice
     socket.emit('game-mode', mode);
-    
-    // If playing, show controls
-    if (mode === 'play') {
+
+    // Show controls when playing a single-player game
+    if (mode === 'single') {
       document.getElementById('player-controls').classList.remove('hidden');
     }
   }, 300);

--- a/cluedo_game_engine/public/index.html
+++ b/cluedo_game_engine/public/index.html
@@ -8,7 +8,8 @@
   <div id="mode-selection" class="center-screen">
     <h1>AI Cluedo</h1>
     <div class="mode-options">
-      <button onclick="startGame('spectate')">Start Game</button>
+      <button class="mode-button" onclick="startGame('single')">Single Game</button>
+      <button class="mode-button" onclick="startGame('multi')">Multiple Game</button>
     </div>
   </div>
 

--- a/cluedo_game_engine/public/style.css
+++ b/cluedo_game_engine/public/style.css
@@ -323,7 +323,7 @@ body {
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-.mode-options button {
+.mode-options .mode-button {
   margin: 10px;
   padding: 20px 40px;
   font-size: 1.2em;
@@ -336,7 +336,7 @@ body {
   border: 2px solid transparent;
 }
 
-.mode-options button:hover {
+.mode-options .mode-button:hover {
   background: #3a3a3a;
   border-color: #4ecdc4;
   transform: translateY(-2px);


### PR DESCRIPTION
## Summary
- Add **Single Game** and **Multiple Game** buttons to the mode selection screen
- Pass selected mode to server via `socket.emit('game-mode', mode)` and show controls when single-player
- Style new mode buttons to match existing interface

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b091657e08321b5fb9543cd0b5d36