### PR TITLE
Add configurable multi-game count via UI and server

### DIFF
--- a/cluedo_game_engine/public/index.html
+++ b/cluedo_game_engine/public/index.html
@@ -10,6 +10,7 @@
     <div class="mode-options">
       <button class="mode-button" onclick="startGame('single')">Single Game</button>
       <button class="mode-button" onclick="startGame('multi')">Multiple Game</button>
+      <input id="multi-count" type="number" min="1" value="5" style="width: 60px; margin-left: 8px;" />
     </div>
   </div>
 
@@ -103,8 +104,15 @@
     function startGame(mode) {
       document.getElementById('mode-selection').classList.add('hidden');
       document.getElementById('game-container').classList.remove('hidden');
-      
-      socket.emit('game-mode', mode);
+      const data = { mode };
+      if (mode === 'multi') {
+        const input = document.getElementById('multi-count');
+        const count = parseInt(input?.value, 10);
+        if (!isNaN(count)) {
+          data.count = count;
+        }
+      }
+      socket.emit('game-mode', data);
     }
 
     socket.on('game-event', (event) => {

--- a/cluedo_game_engine/src/server.js
+++ b/cluedo_game_engine/src/server.js
@@ -71,10 +71,14 @@ export async function startServer() {
       socket.emit('leaderboard-update', computeLeaderboard(completedGames));
     }
 
-    socket.on('game-mode', async (mode) => {
+    socket.on('game-mode', async (data) => {
       try {
+        const { mode, count } = typeof data === 'object' ? data : { mode: data };
         if (mode === 'multi') {
-          const numGames = 5; // Or make this configurable
+          let numGames = parseInt(count, 10);
+          if (isNaN(numGames) || numGames <= 0) {
+            numGames = 5; // Default if invalid
+          }
           for (let i = 0; i < numGames; i++) {
             const multiGame = new Game('spectate', io); // UI will spectate
             await multiGame.initialize();


### PR DESCRIPTION
## Summary
- Add numeric input next to "Multiple Game" button to choose number of games
- Emit selected count from startGame and handle it server-side
- Server now parses provided count, validates it, and defaults to 5 if missing or invalid

## Testing
- `npm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b36a3f94c83218233e9fdb6d5470e