### PR TITLE
Add multi-game progress overlay and server events

### DIFF
--- a/cluedo_game_engine/public/index.html
+++ b/cluedo_game_engine/public/index.html
@@ -5,6 +5,13 @@
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
+  <div id="loading-overlay">
+    <div class="loading-content">
+      <div class="spinner"></div>
+      <div id="progress-status">Preparing games...</div>
+      <div id="progress-bar"><div class="progress"></div></div>
+    </div>
+  </div>
   <div id="mode-selection" class="center-screen">
     <h1>AI Cluedo</h1>
     <div class="mode-options">
@@ -103,7 +110,14 @@
     function startGame(mode) {
       document.getElementById('mode-selection').classList.add('hidden');
       document.getElementById('game-container').classList.remove('hidden');
-      
+
+      if (mode === 'multi') {
+        const overlay = document.getElementById('loading-overlay');
+        overlay.classList.add('active');
+        document.querySelector('#progress-bar .progress').style.width = '0%';
+        document.getElementById('progress-status').textContent = 'Starting games...';
+      }
+
       socket.emit('game-mode', mode);
     }
 
@@ -197,6 +211,17 @@
     socket.on('game-solution', (solution) => {
       const solutionDisplay = document.getElementById('solution-display');
       solutionDisplay.textContent = `${solution.suspect} in the ${solution.room} with the ${solution.weapon}`;
+    });
+
+    socket.on('game-progress', ({ total, completed }) => {
+      const percent = (completed / total) * 100;
+      const progress = document.querySelector('#progress-bar .progress');
+      const status = document.getElementById('progress-status');
+      progress.style.width = `${percent}%`;
+      status.textContent = `Completed ${completed} of ${total} games`;
+      if (completed >= total) {
+        document.getElementById('loading-overlay').classList.remove('active');
+      }
     });
 
     // Function to update game board with highlighted rooms

--- a/cluedo_game_engine/public/style.css
+++ b/cluedo_game_engine/public/style.css
@@ -544,3 +544,60 @@ body {
   border-radius: 4px;
   white-space: pre-wrap;
 }
+
+#loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+#loading-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+#loading-overlay .loading-content {
+  text-align: center;
+}
+
+#loading-overlay .spinner {
+  width: 50px;
+  height: 50px;
+  border: 6px solid #444;
+  border-top-color: #4a9eff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 20px;
+}
+
+#progress-bar {
+  width: 300px;
+  height: 10px;
+  background: #333;
+  border-radius: 5px;
+  overflow: hidden;
+  margin: 10px auto 0;
+}
+
+#progress-bar .progress {
+  height: 100%;
+  width: 0%;
+  background: #4a9eff;
+  transition: width 0.3s ease;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/cluedo_game_engine/src/server.js
+++ b/cluedo_game_engine/src/server.js
@@ -81,6 +81,8 @@ export async function startServer() {
             const result = await runGameLoop(multiGame);
             handleGameResult(result);
 
+            io.emit('game-progress', { total: numGames, completed: i + 1 });
+
             // Reset agent memories for the next game in the series
             if (multiGame.agents) {
               for (const agent of multiGame.agents) {
@@ -168,4 +170,4 @@ async function runGameLoop(gameInstance) {
     // Return a partial result on error to avoid crashing the multi-game loop
     return { error: true, message: error.message };
   }
-} 
+}


### PR DESCRIPTION
## Summary
- show a full-screen loading overlay with progress bar during multi-game sessions
- emit `game-progress` events after each game and update the client in real time
- style overlay and progress bar for smooth animated feedback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b36a4be548321801f9b85bbba7d85